### PR TITLE
More architecture fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### Breaking Changes
 ### Added
 ### Fixed
+- A more thorough fix for repositories that have packages for multiple architectures in the same repository.
+  - The archictecture of a package is now stored in the lockfile.
+  - This change is backwards compatible - older versions of rpmoci will ignore this field and may select the wrong package on download.
 
 ## 0.4.1 - 2024-11-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ### Added
 ### Fixed
 - A more thorough fix for repositories that have packages for multiple architectures in the same repository.
-  - The archictecture of a package is now stored in the lockfile.
+  - Packages are filtered by base architecture, and the architecture of a package is now stored in the lockfile
   - This change is backwards compatible - older versions of rpmoci will ignore this field and may select the wrong package on download.
 
 ## 0.4.1 - 2024-11-21

--- a/src/lockfile/download.py
+++ b/src/lockfile/download.py
@@ -26,21 +26,22 @@ def download(base, packages, directory):
     Parameters:
     - base needs to be a dnf.Base() object that has had repos configured and fill_sack called.
     packages is an array of requested package specifications
-    - packages is a list of {name, evr, checksum} dicts.
+    - packages is a list of [name, evr, checksum, arch] lists.
     - directory, where to copy the RPMs to
     """
-    pkgs = [get_package(base, p[0], p[1], p[2]) for p in packages]
+    pkgs = [get_package(base, p[0], p[1], p[2], p[3]) for p in packages]
     base.download_packages(pkgs, MultiFileProgressMeter(fo=sys.stdout))
     for pkg in pkgs:
         shutil.copy(pkg.localPkg(), directory)
 
 
-def get_package(base, name, evr, checksum):
+def get_package(base, name, evr, checksum, arch):
     """Find packages matching given spec."""
-    pkgs = base.sack.query().filter(name=name, evr=evr).run()
+    if arch:
+        pkgs = base.sack.query().filter(name=name, evr=evr, arch=arch).run()
+    else:
+        pkgs = base.sack.query().filter(name=name, evr=evr).run()
     # Filter by checksum manually as hawkey does not support it
-    # This also ensures that we get the package for the correct arch
-    # in case $basearch is used in the URL.
     pkgs = [p for p in pkgs if p.chksum and p.chksum[1].hex() == checksum]
 
     if not pkgs:

--- a/src/lockfile/download.rs
+++ b/src/lockfile/download.rs
@@ -46,7 +46,14 @@ impl Lockfile {
             let packages = self
                 .packages
                 .iter()
-                .map(|p| (p.name.clone(), p.evr.clone(), p.checksum.checksum.clone()))
+                .map(|p| {
+                    (
+                        p.name.clone(),
+                        p.evr.clone(),
+                        p.checksum.checksum.clone(),
+                        p.arch.clone().unwrap_or_default(),
+                    )
+                })
                 .collect::<Vec<_>>();
 
             let args = PyTuple::new(

--- a/src/lockfile/mod.rs
+++ b/src/lockfile/mod.rs
@@ -87,6 +87,11 @@ pub struct Package {
     pub checksum: Checksum,
     /// The id of the package's repository
     pub repoid: String,
+    /// The architecture of the package
+    /// Optional to support older lockfiles. If a new lockfile format is introduced
+    /// that requires this field, it should be made mandatory.
+    #[serde(default)]
+    pub arch: Option<String>,
 }
 
 /// Checksum of RPM package

--- a/src/lockfile/resolve.py
+++ b/src/lockfile/resolve.py
@@ -100,6 +100,7 @@ def pkg_to_dict(pkg):
         "evr": pkg.evr,
         "checksum": chksum_to_dict(pkg.chksum),
         "repoid": pkg.repoid,
+        "arch": pkg.arch,
     }
 
 

--- a/src/lockfile/resolve.py
+++ b/src/lockfile/resolve.py
@@ -76,7 +76,9 @@ def get_packages(base, pkg_spec):
         subj = dnf.subject.Subject(pkg_spec)
         query = subj.get_best_query(base.sack)
         query = query.available()
-        query = query.filterm(latest_per_arch_by_priority=True)
+        query = query.filterm(
+            latest_per_arch_by_priority=True, arch=[base.conf.basearch, "noarch"]
+        )
 
     pkgs = query.run()
     if not pkgs:

--- a/tests/fixtures/basearch/rpmoci.toml
+++ b/tests/fixtures/basearch/rpmoci.toml
@@ -1,5 +1,7 @@
 [contents]
-packages = ["basesystem"]
+packages = [
+    "libgcc", # has i686 and x86_64 variants
+    "basesystem"] # is noarch
 
 [[contents.repositories]]
 url = "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/os"


### PR DESCRIPTION
When requesting packages that have multiple architectures in the same repository, the packages are now filtered by base architecture (or noarch). This fixes an issue where `rpmoci update` fails as rpmoci attempts to select both variants, causing a conflict.

The lockfile is now explicitly architecture specific, by including the architecture of packages in the lockfile.