### PR TITLE
when using vendored RPMs, verify checksums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,6 +1973,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "tar",
  "tempfile",
  "termcolor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ url = { version = "2.2.2", features = ["serde"] }
 walkdir = "2.3.2"
 xattr = "1.0.1"
 ocidir = "0.3.1"
+sha2 = "0.10.8"
 
 [dev-dependencies]
 libc = "0.2.164"

--- a/src/lockfile/mod.rs
+++ b/src/lockfile/mod.rs
@@ -15,6 +15,7 @@
 //! You should have received a copy of the GNU General Public License
 //! along with this program.  If not, see <https://www.gnu.org/licenses/>.
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fmt;
 use std::io::Write;
 use std::path::Path;
 
@@ -117,6 +118,18 @@ pub enum Algorithm {
     SHA384,
     /// The SHA512 algorithm
     SHA512,
+}
+
+impl fmt::Display for Algorithm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Algorithm::MD5 => write!(f, "md5"),
+            Algorithm::SHA1 => write!(f, "sha1"),
+            Algorithm::SHA256 => write!(f, "sha256"),
+            Algorithm::SHA384 => write!(f, "sha384"),
+            Algorithm::SHA512 => write!(f, "sha512"),
+        }
+    }
 }
 
 impl Lockfile {


### PR DESCRIPTION
we already check gpg signatures for signed packages, but this provides an integrity check when using unsigned packages 